### PR TITLE
Fixing nickname container inconsistency

### DIFF
--- a/static/styles/easel.css
+++ b/static/styles/easel.css
@@ -19,6 +19,7 @@
   content: attr(tag);
 
   position: absolute;
+  width: max-content;
   max-width: 200px;
   left: 50%;
   top: -50%;


### PR DESCRIPTION
Example:
![Screenshot_20250124_150016](https://github.com/user-attachments/assets/c1a62a5b-2323-4dd1-ad2b-2f9cbd3b56a2)
The extra style rule, proposed in the commit, fixes this.
